### PR TITLE
Avoid overflow of hi-res image all around

### DIFF
--- a/src/qml/pages/CallView.qml
+++ b/src/qml/pages/CallView.qml
@@ -75,6 +75,16 @@ Page {
         Image {
             id: avatar
             anchors.horizontalCenter: parent.horizontalCenter
+            asynchronous: true
+            fillMode: Image.PreserveAspectCrop
+            width: (avatar.implicitWidth < Theme.itemWidthMedium) ? avatar.implicitWidth : Theme.itemWidthMedium
+            height: width
+            horizontalAlignment: Image.AlignHCenter
+            verticalAlignment: Image.AlignVCenter
+
+            sourceSize.width: 1024
+            sourceSize.height: 1024
+
             source: main.activeVoiceCallPerson
                     ? main.activeVoiceCallPerson.avatarPath
                     : 'image://theme/user';


### PR DESCRIPTION
The hi-res image shouldn't be scaled. I guess this is unexpected behavior. The difference is shown on photos below.
Additionally, dialog have sourceSize limitation and asynchronous mode which avoids waiting to render of page while trying to answer incoming call.

![image20230218_171649819](https://user-images.githubusercontent.com/6171637/219876557-d8ed4205-97c3-494a-a5e0-d14664dda68f.jpg)
![image20230218_171804367](https://user-images.githubusercontent.com/6171637/219876560-d4c4f0fc-eb04-4b61-b80a-9dff053f11d3.jpg)

In my opinion some graphical design should be created first. In my opinion the same profile but blurred picture can be stretched over whole page. Some nice animated shader effects could be included.
- https://www.qt.io/blog/in-depth-custom-shader-effects
- https://www.qt.io/blog/introducing-qt-quick-effect-maker
- e.g. before answering of incoming call https://code.qt.io/cgit/qt/qtmultimedia.git/tree/examples/multimedia/video/qmlvideofx/qml/qmlvideofx/EffectShockwave.qml?h=5.15